### PR TITLE
fix titleBarHeight to 28px

### DIFF
--- a/PlayTools/Utils/MaaTools.swift
+++ b/PlayTools/Utils/MaaTools.swift
@@ -211,7 +211,7 @@ final class MaaTools {
         }
 
         // Crop the title bar
-        let titleBarHeight = 56
+        let titleBarHeight = 28
         let contentRect = CGRect(x: 0, y: titleBarHeight, width: image.width,
                                  height: image.height - titleBarHeight)
         guard let image = image.cropping(to: contentRect) else {


### PR DESCRIPTION
标题栏高度为28px，设备Mac mini Apple M2/系统13.3.1 (22E261)。
标题栏高度过导致游戏画面顶部被截掉了，返回按钮识别出现问题。